### PR TITLE
Fix wrong reference to READ_ONCE and WRITE_ONCE macro

### DIFF
--- a/concurrency-primer.tex
+++ b/concurrency-primer.tex
@@ -1270,7 +1270,7 @@ The Linux kernel provides \monobox{READ\_ONCE()} and \monobox{WRITE\_ONCE()}
 macros for this exact purpose.\punckern\footnote{See
 \href{https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/n4374.html}{\textsc{n}4374}
 and the kernel's
-\href{https://elixir.bootlin.com/linux/latest/source/tools/include/linux/compiler.h}{\texttt{compiler.h}} for details.}
+\href{https://elixir.bootlin.com/linux/latest/source/include/asm-generic/rwonce.h}{\texttt{rwonce.h}} for details.}
 
 \section{Takeaways}
 

--- a/concurrency-primer.tex
+++ b/concurrency-primer.tex
@@ -1270,7 +1270,7 @@ The Linux kernel provides \monobox{READ\_ONCE()} and \monobox{WRITE\_ONCE()}
 macros for this exact purpose.\punckern\footnote{See
 \href{https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/n4374.html}{\textsc{n}4374}
 and the kernel's
-\href{https://elixir.bootlin.com/linux/latest/source/include/linux/compiler.h}{\texttt{compiler.h}} for details.}
+\href{https://elixir.bootlin.com/linux/latest/source/tools/include/linux/compiler.h}{\texttt{compiler.h}} for details.}
 
 \section{Takeaways}
 


### PR DESCRIPTION
The original `include/linux/compiler.h` does not contain the definition of READ_ONCE and WRITE_ONCE macro. Other `compiler.h` files locate at `tools/include/linux/compiler.h` and `tools/virtio/linux/compiler.h`. Considering the former ought to be the commonly included one, by it's file placement, I replace the reference with the link to the former.