### PR TITLE
Fix broken link

### DIFF
--- a/concurrency-primer.tex
+++ b/concurrency-primer.tex
@@ -1204,7 +1204,7 @@ See the LWN article,
 by Fedor Pikus,
 a hour-long talk on this topic.
 
-\href{https://channel9.msdn.com/Shows/Going+Deep/Cpp-and-Beyond-2012-Herb-Sutter-atomic-Weapons-1-of-2}{%
+\href{https://herbsutter.com/2013/02/11/atomic-weapons-the-c-memory-model-and-modern-hardware/}{%
 \textit{\cpp|atomic<> Weapons|: The \cplusplus{11} Memory Model and Modern Hardware}}
 by Herb Sutter,
 a three-hour talk that provides a deeper dive.


### PR DESCRIPTION
The original link is redirected to https://learn.microsoft.com/en-us/shows/ 
This commit replaces it with the link to Herb's website.