### PR TITLE
Add ABA problem subsection in "Atomic operations as building blocks"

### DIFF
--- a/concurrency-primer.tex
+++ b/concurrency-primer.tex
@@ -916,7 +916,7 @@ In \monobox{worker} function, we have the thread trying to claim the job.
 
 \begin{ccode}
     job_t *job = atomic_load(&thrd_pool->head->prev);
-    while (!atomic_compare_exchange_strong(&thrd_pool->head->prev, &job,
+    while (!atomic_compare_exchange_weak(&thrd_pool->head->prev, &job,
                                            job->prev)) {
     }
 \end{ccode}
@@ -930,23 +930,46 @@ Consider the following scenario:
     \item Thread B sets thread pool state to idle.
     \item Main thread fininshes waiting and adds more jobs.
     \item Memory allocator reuses the recently freed memory as new jobs addresses.
-    \item Fortunately, the first added job has the same address as the one Thread A holded.
+    \item Fortunately, the first added job has the same address as the one thread A holded.
     \item Thread A is back in running state. The comparison result is equal so it updates \monobox{thrd\_pool->head->prev} with the old \monobox{job->prev}, which is already a dangling pointer.
     \item Another thread loads the dangling pointer from \monobox{thrd\_pool->head->prev}.
 \end{enumerate}
 
-Notice that even though \monobox{job->prev} is not loaded explicitly before comparison, compiler could place loading instructions before comparison.
+Notice that even though \monobox{job->prev} is not loaded explicitly before comparison, compiler could place loading instructions before comparison. 
 At the end, the dangling pointer could either point to garbage or trigger segmentation fault.
 It could be even worse if nested ABA problem occurs in thread B.
+Also, the possibility to allocate a job with same address could be higher when using memory pool, meaning that more chances to have ABA problem occurred.
+In fact, pre-allocated memory should be used to achive lock-free since \monobox{malloc} could have mutex involved in multithreaded environment.
 
 Failure to recognize changed target object through comparison can result in stale information.
 The general concept of solving this problem involves adding more information to make different state distinguishable, and then making a decision on whether to act on the old state or retry with the new state.
 If acting on the old state is chosen, then safe memory reclamation should be considered as memory may have already been freed by other threads.
 More aggressively, one might consider the programming paradigm where each operation on the target object does not have a side effect on modifying it.
-In the later section, we will introduce a different way of implementing atomic \textsc{RMW} operations by using LL/SC instructions. The exclusiveness provided by LL/SC instructions avoids the pitfall introduced by comparison.
+In the later section, we will introduce a different way of implementing atomic \textsc{RMW} operations by using LL/SC instructions. The exclusive status provided by LL/SC instructions avoids the pitfall introduced by comparison.
 
-To make different state distinguishable, a common solution is adding a version number to be compared as well.
+To make different state distinguishable, a common solution is incrementing a version number each time target object is changed.
+By bundling the target object and version into a comparison, it ensures that each change marks a distinguishable result.
+Given a sufficient large size for version number, there should be no repeated version numbers.
+There are multiple methods for storing the version number, depending on the evaluation of the duration before a version number wraps around.
+In the thread pool example, the target object is a pointer. The unused bits in a pointer can be utilized to store the version number.
+In addition to embedding the version number into a pointer, we could consider utilizing an additional 32-bit or 64-bit value next to the target object for the version number.
+It requires the compare-and-swap instruction to be capable of comparing a wider size at once.
+Sometimes, this is referred to as \introduce{double-width compare-and-swap}.
+On x86-64 processors, for atomic instructions that load or store more that a CPU word size, it needs additional hardware support.
+You can use \monobox{grep cx16 /proc/crpuinfo} to check if the processor supports 16-byte compare-and-swap.
+For hardware that does not support the desired size, software implementations which may have locks involve are used instead as mentioned in \secref{arbitrarily-size}.
+Back to the example, the following code is fixed by using an an version number that increments each time a job is added to the empty queue. On x86-64, add a compiler flag \monobox{-mcx64} to enable 16-byte compare-and-swap in \monobox{worker} function.
 
+\inputminted{c}{./examples/rmw_example_aba.c}
+
+Notice that, in the \monobox{struct idle\_job}, a union is used for type punning, which bundles the pointer and version number for compare-and-swap.
+Directly casting a job pointer to a pointer that points to a 16-byte object is undefined behavior (due to having different alignment), thus type punnined is used instead.
+By using this techniques, \monobox{struct idle\_job} still can be accessed normally in other places, minimizing code modification.
+Compiler optimizations are conservative on type punning, but it is acceptable for atomic operations.
+See \secref{fusing}.
+Another way to prevent ABA problem in the example is using safe memory reclamation mechanisms.
+Different from previously mentioned acting on the old state, the address of a job is not freed until no one is using it.
+This prevents memory allocator or memory pool reuses the address and causing problem.
 
 \section{Sequential consistency on weakly-ordered hardware}
 

--- a/concurrency-primer.tex
+++ b/concurrency-primer.tex
@@ -939,7 +939,7 @@ Notice that even though \monobox{job->prev} is not loaded explicitly before comp
 At the end, the dangling pointer could either point to garbage or trigger segmentation fault.
 It could be even worse if nested ABA problem occurs in thread B.
 Also, the possibility to allocate a job with same address could be higher when using memory pool, meaning that more chances to have ABA problem occurred.
-In fact, pre-allocated memory should be used to achieve lock-free since \monobox{malloc} could have mutex involved in multithreaded environment.
+In fact, pre-allocated memory should be used to achieve lock-free since \monobox{malloc} could have mutex involved in multi-threaded environment.
 
 Failure to recognize changed target object through comparison can result in stale information.
 The general concept of solving this problem involves adding more information to make different state distinguishable, and then making a decision on whether to act on the old state or retry with the new state.

--- a/concurrency-primer.tex
+++ b/concurrency-primer.tex
@@ -886,25 +886,67 @@ a domain fraught with challenges.
 \subsection{ABA problem}
 We have introduced CAS as one of the read-modify-write operations.
 However, does the target object not changing really mean that no other threads modified it halfway through?
+If the target object is changed to something by other thread and changed back, the result of comparison is still equal.
+Although the target object has indeed been changed, causing the operation not remaining atomic.
+We call this \introduce{ABA problem}.
 Consider the following scenario,
 
+\inputminted{c}{./examples/simple_aba_example.c}
+
+Compile it with \monobox{gcc -std=c11 -Wall -Wextra -pthread simple\_aba\_example.c}.
+The execution result would be:
+
 \begin{ccode}
-    /* example code place holder */
-    do { /* read and modify */ }
-    /* something can happen in between */
-    while(CAS);
+    A: v = 42
+    B: v = 47
+    B: v = 42
+    A: v = 52
 \end{ccode}
 
-If the target object is changed to something by other thread and changed back, the result of comparism is still equal.
-Although the target object has indeed been changed, causing the operation to not remain atomic.
-We call this \introduce{ABA problem}. In the example above, the presents of ABA problem leads to
+In the example provided, the presence of ABA problem results in thread A being unaware that variable \monobox{v} has been altered.
+Since the comparison result indicates \monobox{v} unchanged, \monobox{v + 10} is swapped in.
+Here sleeping is only used to ensure the occurance of ABA problem.
+In real world scenario, instead of sleeping, thread A could paused by being context switched for other tasks, including being preempted by higher priority tasks.
+This example seems harmless, but things can get nasty when atomic \textsc{RMW} operations are used in more complex data structures.
 
-The ABA problem occurs when changes occur between reading and comparing, but the comparing mechanism is unable to identify that the state is not the latest.
-The maximum number we refer to may not be the actual maximum, and the next job may not be the same job.
-Failure to recognize this through comparison can result in outdated information.
+In a broader context, the ABA problem occurs when changes occur between loading and comparing, but the comparing mechanism is unable to identify that the state of the target object is not the latest, yielding a false positive result.
+
+Back to thread pool example in \secref{rmw}, it contains ABA problem as well.
+In \monobox{worker} function, we have the thread trying to claim the job.
+
+\begin{ccode}
+    job_t *job = atomic_load(&thrd_pool->head->prev);
+    while (!atomic_compare_exchange_strong(&thrd_pool->head->prev, &job,
+                                           job->prev)) {
+    }
+\end{ccode}
+
+Consider the following scenario:
+\begin{enumerate}
+    \item There is only one job left.
+    \item Thread A loads the pointer to the job by \monobox{atomic\_load()}.
+    \item Thread A is preempted.
+    \item Thread B claims the job and successfully updates \monobox{thrd\_pool->head->prev}.
+    \item Thread B sets thread pool state to idle.
+    \item Main thread fininshes waiting and adds more jobs.
+    \item Memory allocator reuses the recently freed memory as new jobs addresses.
+    \item Fortunately, the first added job has the same address as the one Thread A holded.
+    \item Thread A is back in running state. The comparison result is equal so it updates \monobox{thrd\_pool->head->prev} with the old \monobox{job->prev}, which is already a dangling pointer.
+    \item Another thread loads the dangling pointer from \monobox{thrd\_pool->head->prev}.
+\end{enumerate}
+
+Notice that even though \monobox{job->prev} is not loaded explicitly before comparison, compiler could place loading instructions before comparison.
+At the end, the dangling pointer could either point to garbage or trigger segmentation fault.
+It could be even worse if nested ABA problem occurs in thread B.
+
+Failure to recognize changed target object through comparison can result in stale information.
 The general concept of solving this problem involves adding more information to make different state distinguishable, and then making a decision on whether to act on the old state or retry with the new state.
 If acting on the old state is chosen, then safe memory reclamation should be considered as memory may have already been freed by other threads.
 More aggressively, one might consider the programming paradigm where each operation on the target object does not have a side effect on modifying it.
+In the later section, we will introduce a different way of implementing atomic \textsc{RMW} operations by using LL/SC instructions. The exclusiveness provided by LL/SC instructions avoids the pitfall introduced by comparison.
+
+To make different state distinguishable, a common solution is adding a version number to be compared as well.
+
 
 \section{Sequential consistency on weakly-ordered hardware}
 

--- a/concurrency-primer.tex
+++ b/concurrency-primer.tex
@@ -902,8 +902,8 @@ The execution result would be:
     A: v = 52
 \end{ccode}
 
-In the example provided, the presence of ABA problem results in thread A being unaware that variable \monobox{v} has been altered.
-Since the comparison result indicates \monobox{v} unchanged, \monobox{v + 10} is swapped in.
+In the example provided, the presence of ABA problem results in thread A being unaware that variable \cc{v} has been altered.
+Since the comparison result indicates \cc{v} unchanged, \cc{v + 10} is swapped in.
 Here sleeping is only used to ensure the occurrence of ABA problem.
 In real world scenario, instead of sleeping, thread A could paused by being context switched for other tasks, including being preempted by higher priority tasks.
 This example seems harmless, but things can get nasty when atomic \textsc{RMW} operations are used in more complex data structures.
@@ -924,18 +924,18 @@ In \monobox{worker} function, we have the thread trying to claim the job.
 Consider the following scenario:
 \begin{enumerate}
     \item There is only one job left.
-    \item Thread A loads the pointer to the job by \monobox{atomic\_load()}.
+    \item Thread A loads the pointer to the job by \cc{atomic_load()}.
     \item Thread A is preempted.
-    \item Thread B claims the job and successfully updates \monobox{thrd\_pool->head->prev}.
+    \item Thread B claims the job and successfully updates \cc{thrd_pool->head->prev}.
     \item Thread B sets thread pool state to idle.
     \item Main thread finishes waiting and adds more jobs.
     \item Memory allocator reuses the recently freed memory as new jobs addresses.
     \item Fortunately, the first added job has the same address as the one thread A held.
-    \item Thread A is back in running state. The comparison result is equal so it updates \monobox{thrd\_pool->head->prev} with the old \monobox{job->prev}, which is already a dangling pointer.
-    \item Another thread loads the dangling pointer from \monobox{thrd\_pool->head->prev}.
+    \item Thread A is back in running state. The comparison result is equal so it updates \cc{thrd_pool->head->prev} with the old \cc{job->prev}, which is already a dangling pointer.
+    \item Another thread loads the dangling pointer from \cc{thrd_pool->head->prev}.
 \end{enumerate}
 
-Notice that even though \monobox{job->prev} is not loaded explicitly before comparison, compiler could place loading instructions before comparison. 
+Notice that even though \cc{job->prev} is not loaded explicitly before comparison, compiler could place loading instructions before comparison. 
 At the end, the dangling pointer could either point to garbage or trigger segmentation fault.
 It could be even worse if nested ABA problem occurs in thread B.
 Also, the possibility to allocate a job with same address could be higher when using memory pool, meaning that more chances to have ABA problem occurred.
@@ -956,15 +956,15 @@ In addition to embedding the version number into a pointer, we could consider ut
 It requires the compare-and-swap instruction to be capable of comparing a wider size at once.
 Sometimes, this is referred to as \introduce{double-width compare-and-swap}.
 On x86-64 processors, for atomic instructions that load or store more than a CPU word size, it needs additional hardware support.
-You can use \monobox{\$ grep cx16 /proc/cpuinfo} to check if the processor supports 16-byte compare-and-swap.
+You can use \monobox{grep cx16 /proc/cpuinfo} to check if the processor supports 16-byte compare-and-swap.
 For hardware that does not support the desired size, software implementations which may have locks involve are used instead, as mentioned in \secref{atomictype}.
 Back to the example, ABA problem in the following code is fixed by using an version number that increments each time a job is added to the empty queue. On x86-64, add a compiler flag \monobox{-mcx16} to enable 16-byte compare-and-swap in \monobox{worker} function.
 
 \inputminted{c}{./examples/rmw_example_aba.c}
 
-Notice that, in the \monobox{struct idle\_job}, a union is used for type punning, which bundles the pointer and version number for compare-and-swap.
+Notice that, in the \cc{struct idle_job}, a union is used for type punning, which bundles the pointer and version number for compare-and-swap.
 Directly casting a job pointer to a pointer that points to a 16-byte object is undefined behavior (due to having different alignment), thus type punning is used instead.
-By using this techniques, \monobox{struct idle\_job} still can be accessed normally in other places, minimizing code modification.
+By using this techniques, \cc{struct idle_job} still can be accessed normally in other places, minimizing code modification.
 Compiler optimizations are conservative on type punning, but it is acceptable for atomic operations.
 See \secref{fusing}.
 Another way to prevent ABA problem in the example is using safe memory reclamation mechanisms.

--- a/concurrency-primer.tex
+++ b/concurrency-primer.tex
@@ -893,7 +893,6 @@ Consider the following scenario,
 
 \inputminted{c}{./examples/simple_aba_example.c}
 
-Compile it with \monobox{gcc -std=c11 -Wall -Wextra -pthread simple\_aba\_example.c}.
 The execution result would be:
 
 \begin{ccode}
@@ -916,9 +915,10 @@ In \monobox{worker} function, we have the thread trying to claim the job.
 
 \begin{ccode}
     job_t *job = atomic_load(&thrd_pool->head->prev);
+    ...
     while (!atomic_compare_exchange_weak(&thrd_pool->head->prev, &job,
-                                           job->prev)) {
-    }
+                                           job->prev))
+        ;
 \end{ccode}
 
 Consider the following scenario:
@@ -939,7 +939,7 @@ Notice that even though \monobox{job->prev} is not loaded explicitly before comp
 At the end, the dangling pointer could either point to garbage or trigger segmentation fault.
 It could be even worse if nested ABA problem occurs in thread B.
 Also, the possibility to allocate a job with same address could be higher when using memory pool, meaning that more chances to have ABA problem occurred.
-In fact, pre-allocated memory should be used to achive lock-free since \monobox{malloc} could have mutex involved in multithreaded environment.
+In fact, pre-allocated memory should be used to achieve lock-free since \monobox{malloc} could have mutex involved in multithreaded environment.
 
 Failure to recognize changed target object through comparison can result in stale information.
 The general concept of solving this problem involves adding more information to make different state distinguishable, and then making a decision on whether to act on the old state or retry with the new state.
@@ -957,8 +957,8 @@ It requires the compare-and-swap instruction to be capable of comparing a wider 
 Sometimes, this is referred to as \introduce{double-width compare-and-swap}.
 On x86-64 processors, for atomic instructions that load or store more than a CPU word size, it needs additional hardware support.
 You can use \monobox{\$ grep cx16 /proc/cpuinfo} to check if the processor supports 16-byte compare-and-swap.
-For hardware that does not support the desired size, software implementations which may have locks involve are used instead as mentioned in \secref{arbitrarily-size}.
-Back to the example, ABA problem in the following code is fixed by using an version number that increments each time a job is added to the empty queue. On x86-64, add a compiler flag \monobox{-mcx64} to enable 16-byte compare-and-swap in \monobox{worker} function.
+For hardware that does not support the desired size, software implementations which may have locks involve are used instead, as mentioned in \secref{atomictype}.
+Back to the example, ABA problem in the following code is fixed by using an version number that increments each time a job is added to the empty queue. On x86-64, add a compiler flag \monobox{-mcx16} to enable 16-byte compare-and-swap in \monobox{worker} function.
 
 \inputminted{c}{./examples/rmw_example_aba.c}
 

--- a/concurrency-primer.tex
+++ b/concurrency-primer.tex
@@ -941,7 +941,8 @@ It could be even worse if nested ABA problem occurs in thread B.
 Also, the possibility to allocate a job with same address could be higher when using memory pool, meaning that more chances to have ABA problem occurred.
 In fact, pre-allocated memory should be used to achieve lock-free since \monobox{malloc} could have mutex involved in multi-threaded environment.
 
-Failure to recognize changed target object through comparison can result in stale information.
+Being unable to determine whether the target object has been changed through comparison could result in a false positive when the return value of CAS is true.
+Thus, the atomicity provided by CAS is not guaranteed.
 The general concept of solving this problem involves adding more information to make different state distinguishable, and then making a decision on whether to act on the old state or retry with the new state.
 If acting on the old state is chosen, then safe memory reclamation should be considered as memory may have already been freed by other threads.
 More aggressively, one might consider the programming paradigm where each operation on the target object does not have a side effect on modifying it.

--- a/concurrency-primer.tex
+++ b/concurrency-primer.tex
@@ -884,10 +884,10 @@ Balancing complexity and performance is essential in concurrency,
 a domain fraught with challenges.
 
 \subsection{ABA problem}
-We have introduced CAS as one of the read-modify-write operations.
-However, does the target object not changing really mean that no other threads modified it halfway through?
-If the target object is changed to something by other thread and changed back, the result of comparison is still equal.
-Although the target object has indeed been changed, causing the operation not remaining atomic.
+CAS has been introduced as one of the read-modify-write operations.
+However, the target object not changing does not necessarily mean that no other threads modified it halfway through.
+If the target object is changed by another thread and then changed back, the result of comparison would still be equal.
+In this case, the target object has indeed been modified, yet the operation appears unchanged, compromising its atomicity.
 We call this \introduce{ABA problem}.
 Consider the following scenario,
 

--- a/concurrency-primer.tex
+++ b/concurrency-primer.tex
@@ -905,7 +905,7 @@ The execution result would be:
 
 In the example provided, the presence of ABA problem results in thread A being unaware that variable \monobox{v} has been altered.
 Since the comparison result indicates \monobox{v} unchanged, \monobox{v + 10} is swapped in.
-Here sleeping is only used to ensure the occurance of ABA problem.
+Here sleeping is only used to ensure the occurrence of ABA problem.
 In real world scenario, instead of sleeping, thread A could paused by being context switched for other tasks, including being preempted by higher priority tasks.
 This example seems harmless, but things can get nasty when atomic \textsc{RMW} operations are used in more complex data structures.
 
@@ -928,9 +928,9 @@ Consider the following scenario:
     \item Thread A is preempted.
     \item Thread B claims the job and successfully updates \monobox{thrd\_pool->head->prev}.
     \item Thread B sets thread pool state to idle.
-    \item Main thread fininshes waiting and adds more jobs.
+    \item Main thread finishes waiting and adds more jobs.
     \item Memory allocator reuses the recently freed memory as new jobs addresses.
-    \item Fortunately, the first added job has the same address as the one thread A holded.
+    \item Fortunately, the first added job has the same address as the one thread A held.
     \item Thread A is back in running state. The comparison result is equal so it updates \monobox{thrd\_pool->head->prev} with the old \monobox{job->prev}, which is already a dangling pointer.
     \item Another thread loads the dangling pointer from \monobox{thrd\_pool->head->prev}.
 \end{enumerate}
@@ -963,7 +963,7 @@ Back to the example, ABA problem in the following code is fixed by using an vers
 \inputminted{c}{./examples/rmw_example_aba.c}
 
 Notice that, in the \monobox{struct idle\_job}, a union is used for type punning, which bundles the pointer and version number for compare-and-swap.
-Directly casting a job pointer to a pointer that points to a 16-byte object is undefined behavior (due to having different alignment), thus type punnined is used instead.
+Directly casting a job pointer to a pointer that points to a 16-byte object is undefined behavior (due to having different alignment), thus type punning is used instead.
 By using this techniques, \monobox{struct idle\_job} still can be accessed normally in other places, minimizing code modification.
 Compiler optimizations are conservative on type punning, but it is acceptable for atomic operations.
 See \secref{fusing}.

--- a/concurrency-primer.tex
+++ b/concurrency-primer.tex
@@ -883,6 +883,29 @@ The performance impact varies with numerous factors, such as thread count and CP
 Balancing complexity and performance is essential in concurrency, 
 a domain fraught with challenges.
 
+\subsection{ABA problem}
+We have introduced CAS as one of the read-modify-write operations.
+However, does the target object not changing really mean that no other threads modified it halfway through?
+Consider the following scenario,
+
+\begin{ccode}
+    /* example code place holder */
+    do { /* read and modify */ }
+    /* something can happen in between */
+    while(CAS);
+\end{ccode}
+
+If the target object is changed to something by other thread and changed back, the result of comparism is still equal.
+Although the target object has indeed been changed, causing the operation to not remain atomic.
+We call this \introduce{ABA problem}. In the example above, the presents of ABA problem leads to
+
+The ABA problem occurs when changes occur between reading and comparing, but the comparing mechanism is unable to identify that the state is not the latest.
+The maximum number we refer to may not be the actual maximum, and the next job may not be the same job.
+Failure to recognize this through comparison can result in outdated information.
+The general concept of solving this problem involves adding more information to make different state distinguishable, and then making a decision on whether to act on the old state or retry with the new state.
+If acting on the old state is chosen, then safe memory reclamation should be considered as memory may have already been freed by other threads.
+More aggressively, one might consider the programming paradigm where each operation on the target object does not have a side effect on modifying it.
+
 \section{Sequential consistency on weakly-ordered hardware}
 
 Different hardware architectures offer distinct memory models or \introduce{memory models}.

--- a/concurrency-primer.tex
+++ b/concurrency-primer.tex
@@ -955,10 +955,10 @@ In the thread pool example, the target object is a pointer. The unused bits in a
 In addition to embedding the version number into a pointer, we could consider utilizing an additional 32-bit or 64-bit value next to the target object for the version number.
 It requires the compare-and-swap instruction to be capable of comparing a wider size at once.
 Sometimes, this is referred to as \introduce{double-width compare-and-swap}.
-On x86-64 processors, for atomic instructions that load or store more that a CPU word size, it needs additional hardware support.
-You can use \monobox{grep cx16 /proc/crpuinfo} to check if the processor supports 16-byte compare-and-swap.
+On x86-64 processors, for atomic instructions that load or store more than a CPU word size, it needs additional hardware support.
+You can use \monobox{\$ grep cx16 /proc/cpuinfo} to check if the processor supports 16-byte compare-and-swap.
 For hardware that does not support the desired size, software implementations which may have locks involve are used instead as mentioned in \secref{arbitrarily-size}.
-Back to the example, the following code is fixed by using an an version number that increments each time a job is added to the empty queue. On x86-64, add a compiler flag \monobox{-mcx64} to enable 16-byte compare-and-swap in \monobox{worker} function.
+Back to the example, ABA problem in the following code is fixed by using an version number that increments each time a job is added to the empty queue. On x86-64, add a compiler flag \monobox{-mcx64} to enable 16-byte compare-and-swap in \monobox{worker} function.
 
 \inputminted{c}{./examples/rmw_example_aba.c}
 
@@ -969,7 +969,7 @@ Compiler optimizations are conservative on type punning, but it is acceptable fo
 See \secref{fusing}.
 Another way to prevent ABA problem in the example is using safe memory reclamation mechanisms.
 Different from previously mentioned acting on the old state, the address of a job is not freed until no one is using it.
-This prevents memory allocator or memory pool reuses the address and causing problem.
+This prevents memory allocator or memory pool from reusing the address and causing problem.
 
 \section{Sequential consistency on weakly-ordered hardware}
 

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,8 +1,10 @@
 all:
 	$(CC) -Wall -o rmw_example rmw_example.c -pthread -lm
 	$(CC) -Wall -o rmw_example_aba rmw_example_aba.c -pthread -lm -mcx16
+	$(CC) -Wall -o simple_aba_example simple_aba_example.c -pthread
 clean:
-	rm -f rmw_example rmw_example_aba
+	rm -f rmw_example rmw_example_aba simple_aba_example 
 check: all
 	./rmw_example
 	./rmw_example_aba
+	./simple_aba_example 

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,6 +1,8 @@
 all:
 	$(CC) -Wall -o rmw_example rmw_example.c -pthread -lm
+	$(CC) -Wall -o rmw_example_aba rmw_example_aba.c -pthread -lm -mcx16
 clean:
-	rm -f rmw_example
+	rm -f rmw_example rmw_example_aba
 check: all
 	./rmw_example
+	./rmw_example_aba

--- a/examples/rmw_example_aba.c
+++ b/examples/rmw_example_aba.c
@@ -1,0 +1,192 @@
+#include <stdalign.h>
+#include <stdio.h>
+#include <stdatomic.h>
+#include <threads.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <assert.h>
+
+#define CACHE_LINE_SIZE 64
+#define N_JOBS 16
+#define N_THREADS 8
+
+typedef struct job {
+    void *args;
+    struct job *next, *prev;
+} job_t;
+
+typedef struct idle_job {
+    union {
+        struct {
+            _Atomic(job_t *) prev;
+            unsigned long long version;
+        };
+        _Atomic struct B16 {
+            job_t *_prev;
+            unsigned long long _version;
+        } DCAS;
+    };
+    char padding[CACHE_LINE_SIZE - sizeof(_Atomic(job_t *)) -
+                 sizeof(unsigned long long)];
+    job_t job;
+} idle_job_t;
+
+enum state { idle, running, cancelled };
+
+typedef struct thread_pool {
+    atomic_flag initialezed;
+    int size;
+    thrd_t *pool;
+    atomic_int state;
+    thrd_start_t func;
+    // job queue is a SPMC ring buffer
+    idle_job_t *head;
+} thread_pool_t;
+
+static int worker(void *args)
+{
+    if (!args)
+        return EXIT_FAILURE;
+    thread_pool_t *thrd_pool = (thread_pool_t *)args;
+
+    while (1) {
+        if (atomic_load(&thrd_pool->state) == cancelled)
+            return EXIT_SUCCESS;
+        if (atomic_load(&thrd_pool->state) == running) {
+            // claim the job
+            struct B16 job = atomic_load(&thrd_pool->head->DCAS);
+            struct B16 next;
+            do {
+                next._prev = job._prev->prev;
+                next._version = job._version;
+            } while (!atomic_compare_exchange_weak(&thrd_pool->head->DCAS, &job,
+                                                   next));
+
+            if (job._prev->args == NULL) {
+                atomic_store(&thrd_pool->state, idle);
+            } else {
+                printf("Hello from job %d\n", *(int *)job._prev->args);
+                free(job._prev->args);
+                free(job._prev); // could cause dangling pointer in other threads
+            }
+        } else {
+            /* To auto run when jobs added, set status to running if job queue is not empty.
+             * As long as the producer is protected */
+            thrd_yield();
+            continue;
+        }
+    };
+}
+
+static bool thread_pool_init(thread_pool_t *thrd_pool, size_t size)
+{
+    if (atomic_flag_test_and_set(&thrd_pool->initialezed)) {
+        printf("This thread pool has already been initialized.\n");
+        return false;
+    }
+
+    assert(size > 0);
+    thrd_pool->pool = malloc(sizeof(thrd_t) * size);
+    if (!thrd_pool->pool) {
+        printf("Failed to allocate thread identifiers.\n");
+        return false;
+    }
+
+    // May use memory pool for jobs
+    idle_job_t *idle_job = malloc(sizeof(idle_job_t));
+    if (!idle_job) {
+        printf("Failed to allocate idle job.\n");
+        return false;
+    }
+    // idle_job will always be the first job
+    idle_job->job.args = NULL;
+    idle_job->job.next = &idle_job->job;
+    idle_job->job.prev = &idle_job->job;
+    idle_job->prev = &idle_job->job;
+    idle_job->version = 0ULL;
+    thrd_pool->func = worker;
+    thrd_pool->head = idle_job;
+    thrd_pool->state = idle;
+    thrd_pool->size = size;
+
+    for (size_t i = 0; i < size; i++) {
+        thrd_create(thrd_pool->pool + i, worker, thrd_pool);
+        //TODO: error handling
+    }
+
+    return true;
+}
+
+static void thread_pool_destroy(thread_pool_t *thrd_pool)
+{
+    if (atomic_exchange(&thrd_pool->state, cancelled))
+        printf("Thread pool cancelled with jobs still running.\n");
+    for (int i = 0; i < thrd_pool->size; i++) {
+        thrd_join(thrd_pool->pool[i], NULL);
+    }
+    while (thrd_pool->head->prev != &thrd_pool->head->job) {
+        job_t *job = thrd_pool->head->prev->prev;
+        free(thrd_pool->head->prev);
+        thrd_pool->head->prev = job;
+    }
+    free(thrd_pool->head);
+    free(thrd_pool->pool);
+    atomic_fetch_and(&thrd_pool->state, 0);
+    atomic_flag_clear(&thrd_pool->initialezed);
+}
+
+__attribute__((nonnull(2))) static bool add_job(thread_pool_t *thrd_pool,
+                                                void *args)
+{
+    // May use memory pool for jobs
+    job_t *job = malloc(sizeof(job_t));
+    if (!job)
+        return false;
+
+    // unprotected producer
+    job->args = args;
+    job->next = thrd_pool->head->job.next;
+    job->prev = &thrd_pool->head->job;
+    thrd_pool->head->job.next->prev = job;
+    thrd_pool->head->job.next = job;
+    if (thrd_pool->head->prev == &thrd_pool->head->job) {
+        thrd_pool->head->prev = job;
+        thrd_pool->head->version += 1;
+        // trap worker at idle job
+        thrd_pool->head->job.prev = &thrd_pool->head->job;
+    }
+
+    return true;
+}
+
+static inline void wait_until(thread_pool_t *thrd_pool, int state)
+{
+    while (atomic_load(&thrd_pool->state) != state) {
+        thrd_yield();
+    }
+}
+
+int main()
+{
+    thread_pool_t thrd_pool = { .initialezed = ATOMIC_FLAG_INIT };
+    if (!thread_pool_init(&thrd_pool, N_THREADS)) {
+        printf("failed to init.\n");
+        return 0;
+    }
+    for (int i = 0; i < N_JOBS; i++) {
+        int *id = malloc(sizeof(int));
+        *id = i;
+        add_job(&thrd_pool, id);
+    }
+    // Due to simplified job queue (not protecting producer), starting the pool manually
+    atomic_store(&thrd_pool.state, running);
+    wait_until(&thrd_pool, idle);
+    for (int i = 0; i < N_JOBS; i++) {
+        int *id = malloc(sizeof(int));
+        *id = i;
+        add_job(&thrd_pool, id);
+    }
+    atomic_store(&thrd_pool.state, running);
+    thread_pool_destroy(&thrd_pool);
+    return 0;
+}

--- a/examples/simple_aba_example.c
+++ b/examples/simple_aba_example.c
@@ -1,0 +1,39 @@
+#include <stdatomic.h>
+#include <stdio.h>
+#include <threads.h>
+#include <unistd.h>
+atomic_int v = 42;
+
+int threadA(void *args)
+{
+    int va;
+    do {
+        va = atomic_load(&v);
+        printf("A: v = %d\n", va);
+        /* Ensure thread B do something before comparing */
+        thrd_sleep(&(struct timespec){ .tv_sec = 1 }, NULL);
+    } while (atomic_compare_exchange_strong(&v, &va, va + 10));
+    printf("A: v = %d\n", atomic_load(&v));
+
+    return 0;
+}
+
+int threadB(void *args)
+{
+    atomic_fetch_add(&v, 5);
+    printf("B: v = %d\n", atomic_load(&v));
+    atomic_fetch_sub(&v, 5);
+    printf("B: v = %d\n", atomic_load(&v));
+
+    return 0;
+}
+
+int main()
+{
+    thrd_t A, B;
+    thrd_create(&A, threadA, NULL);
+    thrd_create(&B, threadB, NULL);
+    /* Ensure all threads complete */
+    thrd_sleep(&(struct timespec){ .tv_sec = 2 }, NULL);
+    return 0;
+}


### PR DESCRIPTION
Root causes and an easy example are first provided, and followed by possible solutions. The thread pool example from #7 is reused as more complex example. Not sure if text description of the example is clear enough. If not, figures could then be added.

Currently the thread pool example that fixed the ABA problem looks fine but I am not fully sure if the problem is really fixed. I will try model checking or formal proofing tools to verify that. If it goes well, it may be added as another section on verifying correctness of concurrent programs.