### PR TITLE
Fix typo

### DIFF
--- a/concurrency-primer.tex
+++ b/concurrency-primer.tex
@@ -477,11 +477,11 @@ if it were executed atomically:
 /* A is an atomic type. C is the non-atomic type corresponding to A */
 bool atomic_compare_exchange_strong(A* obj, C* expected, C desired)
 {
-    if (memcmp(obj, expected, sizeof(*object)) == 0) {
-        memcpy(obj, &desired, sizeof(*object));
+    if (memcmp(obj, expected, sizeof(*obj)) == 0) {
+        memcpy(obj, &desired, sizeof(*obj));
         return true;
     } else {
-        memcpy(expected, obj, sizeof(*object));
+        memcpy(expected, obj, sizeof(*obj));
         return false;
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix a typo in the compare-and-swap example by using sizeof(*obj) instead of sizeof(*object) in memcmp/memcpy. This aligns the snippet with the function parameter and avoids confusion or compile errors.

<sup>Written for commit 68e5e76194aaac8678bdc51da57b20744dd64a37. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/concurrency-primer/pull/21?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

